### PR TITLE
Attempt to report code coverage after successful build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,6 @@ script:
   - npm run lint
   - npm run test
   - rake acceptance_tests
+
+after_success:
+  - npm run ci-report-coverage

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Two-way literate programming between markdown and config files.",
   "main": "index.js",
   "scripts": {
+    "ci-report-coverage": "codeclimate-test-reporter < coverage/lcov.info",
     "lint": "./node_modules/.bin/eslint lib bin gulpfile.js",
     "lint-fix": "./node_modules/.bin/eslint --fix lib bin gulpfile.js",
     "test": "gulp test"
@@ -30,6 +31,7 @@
     "minimist": "^1.2.0"
   },
   "devDependencies": {
+    "codeclimate-test-reporter": "^0.5.0",
     "eslint": "^4.3.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.7.0",


### PR DESCRIPTION
# Overview

Publish code coverage info to Code Climate.

## Detail

As is, we compute code coverage but we don't report it.

As of this writing, this approach uses the "old" version of publishing code coverage numbers to travis.

It depends on a server side env variable being present in travis. eg: https://cl.ly/1y0H3R2X213L