### PR TITLE
Iterate on update-markdown-from-config

### DIFF
--- a/bin/update-markdown-from-config
+++ b/bin/update-markdown-from-config
@@ -1,32 +1,56 @@
 #!/usr/bin/env node
 
-const minimist = require('minimist')
 const argv = require('minimist')(process.argv.slice(2))
+
+const chalk = require('chalk')
+const report = {
+  info: (s) => console.log(chalk.blue(s)),
+  success: (s) => console.log(chalk.green(s)),
+  problem: (s) => console.log(chalk.red(s))
+}
 
 const readFiles = require('../lib/util/readFiles').readFiles
 const writeFile = require('../lib/util/writeFile').writeFile
+const analyzeResults = require('../lib/analyzeResults').analyzeResults
+const analyzePatches = require('../lib/analyzePatches').analyzePatches
 
 const compareConfigs = require('../lib/compareConfigs').compareConfigs
 const updateMarkdownWithDifferences = require('../lib/updateMarkdownWithDifferences').updateMarkdownWithDifferences
 const extractConfigFromMarkdown = require('../lib/extractConfigFromMarkdown').extractConfigFromMarkdown
 
 if (argv.help) {
-  console.log("\nUsage:\n  update-markdown-from-config --config-file <CONFIG_FILE> --markdown-file <MARKDOWN_FILE>\n")
+  console.log('\nUsage:\n  update-markdown-from-config --config-file <CONFIG_FILE> --markdown-file <MARKDOWN_FILE> [--force true]\n')
 } else {
   const markdownFile = argv['markdown-file']
   const configFile = argv['config-file']
+
   readFiles('.', [
     markdownFile,
     configFile
   ])
-  .then(function (results) {
-    const [ oldMarkdown, newConfig ] = results
-    const oldConfig = extractConfigFromMarkdown(oldMarkdown)
-    const configDifferences = compareConfigs(oldConfig, newConfig)
-    const newMarkdown = updateMarkdownWithDifferences(oldMarkdown, configDifferences)
-    writeFile(markdownFile, newMarkdown);
-  })
-  .catch(function(err) {
-    console.error("Ack!", err)
-  });
+    .then(function (results) {
+      const [ oldMarkdown, newConfig ] = results
+      const oldConfig = extractConfigFromMarkdown(oldMarkdown)
+      const patches = compareConfigs(oldConfig, newConfig)
+      analyzePatches({ patches, report })
+      const { newMarkdown, patchResults } = updateMarkdownWithDifferences(oldMarkdown, patches)
+      analyzeResults({ patches, patchResults, report })
+      const configInNewMarkdown = extractConfigFromMarkdown(newMarkdown)
+      if (configInNewMarkdown === newConfig) {
+        writeFile(markdownFile, newMarkdown)
+      } else {
+        report.problem('Rut ro! Could not correctly create markdown file.')
+        report.problem('The code blocks in the new markdown do not match the config.')
+        if (argv['force'] === 'true') {
+          report.info('Writing out markdown file because --force true is present.')
+          writeFile(markdownFile, newMarkdown)
+        } else {
+          report.problem('Refusing to update the markdown. Add "--force true" to override.')
+          process.exit(1)
+        }
+      }
+    })
+    .catch(function (err) {
+      console.error('Ack!', err)
+    })
 }

--- a/features/update-markdown-from-config/force.feature
+++ b/features/update-markdown-from-config/force.feature
@@ -1,0 +1,82 @@
+Feature: update-markdown-from-config --force
+
+  If you want to update a markdown file from a config there's a non-zero
+  chance that what would be "put" into the markdown file won't match the
+  config.
+
+  If this happens there-and-back-again prints a warning and doens't do
+  anything.
+
+  Unless you add `--force true` in which case it'll overwrite.
+
+  Scenario: A problem has been encountered and the user didn't specify --force
+  Given a file named "some.config" with:
+  """
+  {
+    "what": "the what what"
+  }
+  THIS SHOULDN'T CHANGE
+  {
+    "what": "the what what"
+  }
+
+  """
+  And a file named "some.config.md" with:
+  """
+  # some.config
+
+  ```
+  THIS SHOULDN'T CHANGE
+  ```
+  """
+  When I run `update-markdown-from-config --markdown-file some.config.md --config-file some.config`
+  Then the exit status should be 1
+  And the output should match:
+  """
+  Rut ro! Could not correctly create markdown file.
+  The code blocks in the new markdown do not match the config.
+  """
+  And the file "some.config.md" should contain:
+  """
+  # some.config
+
+  ```
+  THIS SHOULDN'T CHANGE
+  ```
+  """
+
+  Scenario: A conflict exists and the user did specify --force
+  Given a file named "some.config" with:
+  """
+  {
+    "what": "the what what"
+  }
+
+  """
+  And a file named "some.config.md" with:
+  """
+  {
+    "what": "the what what"
+  }
+  THIS SHOULDN'T CHANGE
+  {
+    "what": "the what what"
+  }
+
+  """
+  When I run `update-markdown-from-config --markdown-file some.config.md --config-file some.config --force true`
+  Then the exit status should be 0
+  Then the file "some.config.md" should contain:
+  """
+  {
+    "what": "the what what"
+  }
+  {
+    "what": "the what what"
+  }
+  THIS SHOULDN'T CHANGE
+  {
+    "what": "the what what"
+  }
+
+  """

--- a/lib/analyzePatches.js
+++ b/lib/analyzePatches.js
@@ -1,0 +1,21 @@
+'use es6'
+
+const patch = require('./util/patch').patch
+
+function analyzePatches ({ patches, report }) {
+  if (patches.length === 0) {
+    report.info('Nothing to do. No differences between markdown and config.')
+  } else {
+    let message = `There are ${patches.length} patches to apply.`
+    if (patches.length === 1) {
+      message = 'There is 1 patch to apply.'
+    }
+    report.info(message)
+    for (let i = 0; i < patches.length; i++) {
+      const appliedPatch = patch(patches[i])
+      report.info(`Patch ${i + 1}:\n${appliedPatch.asText()}`)
+    }
+  }
+}
+
+exports.analyzePatches = analyzePatches

--- a/lib/analyzeResults.js
+++ b/lib/analyzeResults.js
@@ -1,0 +1,12 @@
+'use es6'
+
+function analyzeResults ({ patches, patchResults, report }) {
+  const patchResultIsFalse = function (patchResult) { return !patchResult }
+  if (patchResults.some(patchResultIsFalse)) {
+    report.problem('Ut oh! Something went wrong')
+  } else {
+    report.success('Yahoo! All patches applied!')
+  }
+}
+
+exports.analyzeResults = analyzeResults

--- a/lib/updateMarkdownWithDifferences.js
+++ b/lib/updateMarkdownWithDifferences.js
@@ -7,7 +7,11 @@ function updateMarkdownWithDifferences (oldMarkdown, patches) {
   dmp.Match_Threshold = dmp.Patch_DeleteThreshold = 1
   const result = dmp.patch_apply(patches, oldMarkdown)
   const newMarkdown = result[0]
-  return newMarkdown
+  const patchResults = result[1]
+  return {
+    newMarkdown,
+    patchResults
+  }
 }
 
 exports.updateMarkdownWithDifferences = updateMarkdownWithDifferences

--- a/lib/util/patch.js
+++ b/lib/util/patch.js
@@ -1,0 +1,36 @@
+'use es6'
+
+const DiffMatchPatch = require('diff-match-patch')
+
+function patch (diffMatchPatchData) {
+  const data = diffMatchPatchData
+
+  return {
+    getStart1: function () {
+      return data.start1
+    },
+
+    getStart2: function () {
+      return data.start2
+    },
+
+    getLength1: function () {
+      return data.length1
+    },
+
+    getLength2: function () {
+      return data.length2
+    },
+
+    getDiffs: function () {
+      return data.diffs
+    },
+
+    asText: function () {
+      const dmp = new DiffMatchPatch()
+      return decodeURI(dmp.patch_toText([ data ]))
+    }
+  }
+}
+
+exports.patch = patch

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "there-and-back-again",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Two-way literate programming between markdown and config files.",
   "main": "index.js",
   "scripts": {
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/jedcn/there-and-back-again#readme",
   "dependencies": {
     "bluebird": "^3.5.0",
+    "chalk": "^2.1.0",
     "diff-match-patch": "^1.0.0",
     "immutable": "^3.8.1",
     "minimist": "^1.2.0"

--- a/test/lib/updateMarkdownWithDifferences-spec.js
+++ b/test/lib/updateMarkdownWithDifferences-spec.js
@@ -15,7 +15,7 @@ describe('updateMarkdownWithDifferences', function () {
       const [ oldMarkdown, newConfig, newMarkdown ] = results
       const oldConfig = extractConfigFromMarkdown(oldMarkdown)
       const patches = compareConfigs(oldConfig, newConfig)
-      const result = updateMarkdownWithDifferences(oldMarkdown, patches)
+      const { newMarkdown: result } = updateMarkdownWithDifferences(oldMarkdown, patches)
       expect(result).toEqual(newMarkdown)
       done()
     })
@@ -29,7 +29,7 @@ describe('updateMarkdownWithDifferences', function () {
       const [ oldMarkdown, newConfig, newMarkdown ] = results
       const oldConfig = extractConfigFromMarkdown(oldMarkdown)
       const patches = compareConfigs(oldConfig, newConfig)
-      const result = updateMarkdownWithDifferences(oldMarkdown, patches)
+      const { newMarkdown: result } = updateMarkdownWithDifferences(oldMarkdown, patches)
       expect(result).toEqual(newMarkdown)
       done()
     })
@@ -43,7 +43,7 @@ describe('updateMarkdownWithDifferences', function () {
       const [ oldMarkdown, newConfig, newMarkdown ] = results
       const oldConfig = extractConfigFromMarkdown(oldMarkdown)
       const patches = compareConfigs(oldConfig, newConfig)
-      const result = updateMarkdownWithDifferences(oldMarkdown, patches)
+      const { newMarkdown: result } = updateMarkdownWithDifferences(oldMarkdown, patches)
       expect(result).toEqual(newMarkdown)
       done()
     })


### PR DESCRIPTION
# Overview

This change sets the stage for me to start using `there-and-back-again`.

## Background

The current approach is about as naive as can be-- and the high level strategy being employed is to explore what *should* happen and write specs around the good behavior.

I'm wondering if what I *actually* need to do is write out aspects of the markdown into the config file. This would let those artifacts delineate code blocks and providing anchoring + context for the patching process.

# TODO

* [x] Fix build failures
* [x] Squash